### PR TITLE
interface support now turned off by default for stability reasons

### DIFF
--- a/org.intrace/build.xml
+++ b/org.intrace/build.xml
@@ -423,6 +423,14 @@
       <jvmarg value="-javaagent:build/jars/intrace-agent.jar=[instru-true" />
     </java>
   </target>
+  <target name="example3" depends="jar,example_build">
+    <java classname="example.InstrumentMeLaunch" fork="true">
+      <classpath>
+        <pathelement path="./build/test" />
+      </classpath>
+      <jvmarg value="-javaagent:build/jars/intrace-agent.jar=[instru-true" />
+    </java>
+  </target>
 
 
   <target name="waitexample" depends="jar,example_build">

--- a/org.intrace/src/org/intrace/agent/AgentSettings.java
+++ b/org.intrace/src/org/intrace/agent/AgentSettings.java
@@ -40,6 +40,7 @@ private InstrCriteria classesToExclude = null;
   private boolean instruEnabled = true;
   private boolean saveTracedClassfiles = false;
   private boolean verboseMode = false;  
+  private boolean _instrumentImplementors = false;
 
   
 
@@ -54,6 +55,7 @@ private InstrCriteria classesToExclude = null;
     instruEnabled = oldInstance.isInstrumentationEnabled();
     saveTracedClassfiles = oldInstance.saveTracedClassfiles();
     verboseMode = oldInstance.isVerboseMode();
+    _instrumentImplementors = oldInstance.instrumentImplementors();
   }
   public AgentSettings(String args)
   {
@@ -138,8 +140,17 @@ public void parseArgs(String args)
       this.classesToExclude = new InstrCriteria(classExcludeRegexStr);
       this.classesToExclude.verboseLogger = this;
     }
+    else if (arg.toLowerCase(Locale.ROOT).equals(
+                                      AgentConfigConstants.INSTRUMENT_IMPLEMENTORS
+                                          + "true"))
+    {
+        this._instrumentImplementors = true;
+    }
   }
 
+  public boolean instrumentImplementors() {
+    return _instrumentImplementors;
+  }
   public boolean isWaitStart()
   {
     return waitStart;

--- a/org.intrace/src/org/intrace/agent/InstrumentedClassWriter.java
+++ b/org.intrace/src/org/intrace/agent/InstrumentedClassWriter.java
@@ -79,6 +79,7 @@ public class InstrumentedClassWriter extends ClassWriter
 	  	  sb.append(InstrCriteria.CLASS_METHOD_DELIMITER);
 	  	  sb.append(name);
 	  	  sb.append(desc);
+		//System.out.println("@#%:" + sb.toString() );
 	      TraceHandler.INSTANCE.writeTraceOutput("DEBUG: method signature: " + sb.toString());
 	    }	  
     MethodVisitor mv = super.visitMethod(access, name, desc, signature,

--- a/org.intrace/src/org/intrace/output/trace/TraceHandler.java
+++ b/org.intrace/src/org/intrace/output/trace/TraceHandler.java
@@ -472,7 +472,7 @@ private static final Object STACK_ELE_DELIM = ",";
                          + "]:" + xiOutput;
 //    if (AgentHelper.getOutputSettings().isStdoutOutputEnabled())
 //    {
-////      System.out.println(traceString);
+//      System.out.println(traceString);
 //    }
 
     if (AgentHelper.getOutputSettings().isFileOutputEnabled())

--- a/org.intrace/src/org/intrace/shared/AgentConfigConstants.java
+++ b/org.intrace/src/org/intrace/shared/AgentConfigConstants.java
@@ -24,6 +24,7 @@ public class AgentConfigConstants
   public static final String OPT_SERVER_PORT = "[serverport-";
   public static final String CALLBACK_PORT = "[callbackport-";
   public static final String EXIT_STACK_TRACE = "[exit-stack-trace-";
+  public static final String INSTRUMENT_IMPLEMENTORS = "[instrument-implementors";
   
   public static final String START_WAIT = "[startwait";
   public static final String START_ACTIVATE = "[startactivate";
@@ -39,5 +40,6 @@ public class AgentConfigConstants
     COMMANDS.add(OPT_SERVER_PORT + "<int>");
     COMMANDS.add(CALLBACK_PORT + "<int>");
     COMMANDS.add(EXIT_STACK_TRACE + "<true/false>");
+    COMMANDS.add(INSTRUMENT_IMPLEMENTORS + "<true/false>");
   }
 }

--- a/org.intrace/testsrc/example/InstrumentMe.java
+++ b/org.intrace/testsrc/example/InstrumentMe.java
@@ -1,0 +1,20 @@
+package example;
+
+import java.util.Arrays;
+
+public class InstrumentMe implements Runnable
+{
+	private byte myField = 1;
+
+  @Override
+  public void run()
+  {
+      byteArg((byte) 0);
+  }
+
+  private void byteArg(byte arg)
+  {
+   this.myField = arg; 
+  }
+
+}

--- a/org.intrace/testsrc/example/InstrumentMeLaunch.java
+++ b/org.intrace/testsrc/example/InstrumentMeLaunch.java
@@ -1,0 +1,27 @@
+package example;
+
+public class InstrumentMeLaunch 
+{
+	public static void main(String args[]) throws Exception {
+		System.out.println("Currently running sample code in background thread.");
+		System.out.println("Make sure this program has -javaagent:./path/to/intrace-agent.jar on its command line.");
+		System.out.println("Start InTrace GUI, download-able at https://mchr3k.github.io/org.intrace/");
+		System.out.println("'Connect' & then configure GUI to trace any of these patterns:\n\n");
+		System.out.println("example.InstrumentMe					-- to trace all methods in class example.InstrumentMe");
+		System.out.println("example.InstrumentMe					-- to trace all methods in class example.InstrumentMeLaunch");
+		System.out.println("example.InstrumentMe#<init>()V				-- to trace this single method.");
+		System.out.println("example.InstrumentMe#run()V					-- to trace this single method.");
+		System.out.println("example.InstrumentMe#byteArg(B)V				-- to trace this single method.");
+		System.out.println("example.InstrumentMeLaunch#<init>()V			-- to trace this single method.");
+		System.out.println("example.InstrumentMeLaunch#main([Ljava/lang/String;)V	-- to trace this single method.\n\n");
+     
+		System.out.println("Press Ctrl+C to quit this program.");
+		Runnable r = new InstrumentMe();
+		while(true) {
+			System.out.println("About to start thread.");
+			new Thread(r).start();
+			Thread.sleep(2000);
+			
+		}
+	}
+}

--- a/org.intrace/testsrc/org/intracetest/agent/AgentSettingsTest.java
+++ b/org.intrace/testsrc/org/intracetest/agent/AgentSettingsTest.java
@@ -64,6 +64,25 @@ public class AgentSettingsTest extends TestCase
     assertEquals(settingsMap.get(AgentConfigConstants.VERBOSE_MODE), "true");
   }
 
+  public void testInstrumentImplementorsSetting() {
+    AgentSettings as1 = new AgentSettings(
+                                             AgentConfigConstants.INSTRUMENT_IMPLEMENTORS
+                                             + "true"
+                                             );
+    assertTrue( "unable to recognize parameter that instruments implementors of interfaces", as1.instrumentImplementors() );
+
+   AgentSettings as2 = new AgentSettings(
+                                             AgentConfigConstants.INSTRUMENT_IMPLEMENTORS
+                                             + "false"
+                                             );
+    assertFalse( "unable to recognize parameter that instruments implementors of interfaces",as2.instrumentImplementors() );
+
+  AgentSettings as3 = new AgentSettings("");
+    assertFalse( "unable to recognize parameter that instruments implementors of interfaces", as3.instrumentImplementors() );
+
+
+  }
+
   public void testInstrCriteria() {
 	InstrCriteria ic = new InstrCriteria("foo|bar");
 


### PR DESCRIPTION
The code for interface support did extra processing on every class in the classloader.  For a large project like an application server with 10-50k classes, time-to-instrument often took several minutes -- unacceptable.

This pull request turns off interface support by default.
To turn it back on, add the following parameter:
[instrument-implementors=true

--Erik
